### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,3 @@ updates:
           - "major"
     cooldown:
       default-days: 7
-      semver-major-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       run: corepack enable
     - name: Install Rust Nightly
       run: rustup toolchain install nightly && rustup component add rustfmt --toolchain nightly
-    - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v1
+    - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v1.6.0
     - name: Install `pandoc`
       run: sudo apt-get update && sudo apt-get install pandoc -y
     - name: Install `wasm-pack`
@@ -35,7 +35,7 @@ jobs:
       with: 
         name: harper-obsidian-plugin.zip
         path: harper-obsidian-plugin.zip
-    - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
+    - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
       with:
         artifacts: harper/packages/obsidian-plugin/main.js,manifest.json
         allowUpdates: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       run: corepack enable
     - name: Install Rust Nightly
       run: rustup toolchain install nightly && rustup component add rustfmt --toolchain nightly
-    - uses: extractions/setup-just@v1
+    - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v1
     - name: Install `pandoc`
       run: sudo apt-get update && sudo apt-get install pandoc -y
     - name: Install `wasm-pack`
@@ -35,7 +35,7 @@ jobs:
       with: 
         name: harper-obsidian-plugin.zip
         path: harper-obsidian-plugin.zip
-    - uses: ncipollo/release-action@v1
+    - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
       with:
         artifacts: harper/packages/obsidian-plugin/main.js,manifest.json
         allowUpdates: true


### PR DESCRIPTION
Two-in-one hardening:

1. Pin third-party GitHub Actions in this repo to commit SHAs (tag preserved as trailing comment).
2. Add Dependabot `github-actions` config (weekly, grouped into `actions-minor-patch` and `actions-major`, with cooldown).

Tracking: DEVPROD-1072.
